### PR TITLE
fix: unable to use react-router on vercel

### DIFF
--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -44,10 +44,5 @@ const routerObjectArr: RouteObject[] = [
   },
 ]
 
-const router = createBrowserRouter(routerObjectArr, {
-  basename:
-    process.env.NODE_ENV === 'production'
-      ? 'big-data-front-end-exam'
-      : undefined,
-})
+const router = createBrowserRouter(routerObjectArr)
 export default router

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
- add vercel.json to config 'rewrite' option
- remove 'basename' option in react-router's createBrowserRouter